### PR TITLE
tweak README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ A list of documented information can be viewed at the [Droidian wiki](https://gi
 
 The device page is available at [devices.droidian.org](https://devices.droidian.org)
 
+Device-specific sources are available at [droidian-devices](https://github.com/droidian-devices)
+
 The porting guide is available at [porting-guide](https://github.com/droidian/porting-guide)
+
 
 ### Getting community help
 


### PR DESCRIPTION
Added [droidian-devices](https://github.com/droidian-devices) to the README for better navigation and accessibility to the device-specific ports page. With this addition, users or developers can conveniently locate the source of device ports.